### PR TITLE
feat: implemented date standardization in transform

### DIFF
--- a/app/etl/transform.py
+++ b/app/etl/transform.py
@@ -45,8 +45,15 @@ def transform(df: pd.DataFrame) -> pd.DataFrame:
                    if any(keyword in col.lower() for keyword in ['date', 'time', 'created', 'updated'])]
     
     for col in date_columns:
-        # TODO (Find & Fix): Date columns are not standardized
-        pass
+        try:
+            df_transformed[col] = pd.to_datetime(df_transformed[col], errors='coerce', infer_datetime_format=True)
+            # Standardize all dates to 'YYYY-MM-DD HH:MM:SS'
+            df_transformed[col] = df_transformed[col].dt.strftime('%Y-%m-%d %H:%M:%S')
+            
+            print(f"✅ Standardized date column '{col}' (e.g., {df_transformed[col].iloc[0]})")
+        except Exception as e:
+            print(f"⚠️ Could not standardize column '{col}': {e}")
+
     
     # TODO (Find & Fix): Text columns are not cleaned (strip, lowercase)
     return df_transformed


### PR DESCRIPTION
## Description

Fixed the issue with unstandardized date columns in `transform.py`.  
Implemented logic to automatically detect and standardize all date/time columns (e.g., `hire_date`, `created_at`, `updated_at`) using `pd.to_datetime()` with a consistent format (`YYYY-MM-DD HH:MM:SS`).  

---

## Semver Changes

- [] Patch (bug fix, no new features)  
- [x] Minor (new features, no breaking changes)  
- [ ] Major (breaking changes)

---

## Issues

Closes #13 — **Standardize Date Columns in Transform Function**

---

## Checklist

- [x] I have read the [Contributing Guidelines](./.github/Contributor_Guide/Contruting.md).  

