### PR TITLE
Fix: corrected default path handling in extract.py (Issue #2)

### DIFF
--- a/app/etl/extract.py
+++ b/app/etl/extract.py
@@ -1,8 +1,11 @@
 import pandas as pd
 import os
-# TODO (Find & Fix)
 
-def extract(path: str = "xyz.csv") -> pd.DataFrame :
+# Get the base directory (app/) relative to this file (app/etl/extract.py)
+BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+DEFAULT_DATA_PATH = os.path.join(BASE_DIR, "data.csv")
+
+def extract(path: str = DEFAULT_DATA_PATH) -> pd.DataFrame :
     """
     Extracts data from CSV, Excel, or JSON file.
     


### PR DESCRIPTION
## Description

> This pull request fixes the incorrect default path in the extract.py module.
The previous implementation pointed to a wrong directory, which caused file-loading errors during the extract phase.
The updated logic ensures that the default path now correctly points to the data source directory, improving stability and consistency across runs.

## Semver Changes

- [x] Patch (bug fix, no new features)
- [ ] Minor (new features, no breaking changes)
- [ ] Major (breaking changes)

## Issues

> Closes #2

## Checklist

- [x] I have read the [Contributing Guidelines](../Contributor_Guide/Contruting.md).

